### PR TITLE
Add JSON API and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Virtual environment
+.env
+venv/
+
+# Database files
+*.db
+*.sqlite3
+
+# OS files
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# CRM Call Tracker
+
+A simple Flask-based web application for tracking incoming calls. Entries are stored in a SQLite database and can be viewed, edited and exported from a browser. This project is ideal for small teams needing a lightweight CRM for phone interactions.
+
+## Features
+
+* Add, edit and delete call logs
+* Filter and search by caller name or status
+* Dashboard statistics for new, followed-up and closed calls
+* Export call logs to CSV
+* JSON API for programmatic access (`/api/calls`)
+
+## Quick start
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the application:
+   ```bash
+   python app.py
+   ```
+   The database is created on first launch.
+
+Set the `DATABASE_FILE` environment variable to override the database path. The server port can be set via `PORT`.
+
+## Testing
+
+Run the test suite with:
+
+```bash
+pytest -q
+```
+
+## Deployment
+The included `Procfile` runs the app with `python app.py`, making it suitable for platforms such as Heroku. For production use consider running via Gunicorn and a reverse proxy.
+
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ Jinja2==3.1.6
 MarkupSafe==3.0.2
 Werkzeug==3.1.3
 gunicorn==21.2.0
+pytest==8.1.1

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import tempfile
+import json
+import sqlite3
+import pytest
+import pathlib
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+import app
+
+@pytest.fixture
+def client(monkeypatch):
+    fd, path = tempfile.mkstemp()
+    os.close(fd)
+    monkeypatch.setattr(app, 'DB_NAME', path)
+    app.init_db()
+    with app.app.test_client() as client:
+        yield client
+    os.remove(path)
+
+def test_create_and_get_call(client):
+    res = client.post('/api/calls', json={'name': 'Alice', 'phone': '123'})
+    assert res.status_code == 201
+    call_id = res.get_json()['id']
+
+    res = client.get(f'/api/calls/{call_id}')
+    assert res.status_code == 200
+    data = res.get_json()
+    assert data['name'] == 'Alice'
+    assert data['phone'] == '123'
+


### PR DESCRIPTION
## Summary
- make DB path and port configurable via env vars
- add helper to convert rows to dictionaries
- implement JSON API endpoints for listing and creating calls
- add README and gitignore
- add tests for the new API

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f8d873880832480f772501ab4ed35